### PR TITLE
Fix ARM build (curl install fails)

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -6,13 +6,13 @@ COPY security /security
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 
 USER root
-RUN apt update && apt install curl -y
+
+# curl install throws error in ARM64 arch. It should not prevent build
+RUN apt update && apt install -y curl || true
 
 RUN mkdir /var/lib/goerli-besu
 RUN chown -R besu:besu /var/lib/goerli-besu
 
 USER besu
-
-ENV BESU_OPTS=$BESU_OPTS
 
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/build/entrypoint.sh
+++ b/build/entrypoint.sh
@@ -27,9 +27,14 @@ case "$_DAPPNODE_GLOBAL_CONSENSUS_CLIENT_PRATER" in
   ;;
 esac
 
-# Print the jwt to the dappmanager
-JWT=$(cat $JWT_PATH)
-curl -X POST "http://my.dappnode/data-send?key=jwt&data=${JWT}"
+# Check if curl is installed
+if command -v curl >/dev/null 2>&1; then
+    # Print the jwt to the dappmanager
+    JWT=$(cat $JWT_PATH)
+    curl -X POST "http://my.dappnode/data-send?key=jwt&data=${JWT}"
+else
+    echo "curl is not installed in ARM64 arch. Skipping the JWT post to package info."
+fi
 
 exec besu --rpc-ws-host='0.0.0.0' \
   --network=goerli \


### PR DESCRIPTION
`curl` cannot be installed in ARM like this. As it is not critical, we can omit the error and skip the POST of the JWT to the dappmanager for the ARM arch