### PR TITLE
Add seccomp unconfined

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,5 +21,7 @@ services:
       BESU_OPTS: ""
     image: "goerli-besu.goerli-besu.dnp.dappnode.eth:0.1.0"
     restart: unless-stopped
+    security_opt:
+      - "seccomp:unconfined"
 volumes:
   data: {}


### PR DESCRIPTION
Add seccomp unconfined. Fixes:

```
Using prysm.dnp.dappnode.eth
curl: (6) getaddrinfo() thread failed to start

ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH.

Please set the JAVA_HOME variable in your environment to match the
location of your Java installation.

Using prysm.dnp.dappnode.eth
curl: (6) getaddrinfo() thread failed to start

ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH.

Please set the JAVA_HOME variable in your environment to match the
location of your Java installation.
```